### PR TITLE
Adds functions v2 for app APIs

### DIFF
--- a/infrastructure/azure.tf
+++ b/infrastructure/azure.tf
@@ -410,6 +410,7 @@ locals {
   azurerm_app_service_plan_name             = "${var.azurerm_resource_name_prefix}-app-${var.environment_short}"
   azurerm_functionapp_name                  = "${var.azurerm_resource_name_prefix}-functions-${var.environment_short}"
   azurerm_functionapp_services_name         = "${var.azurerm_resource_name_prefix}-functions-services-${var.environment_short}"
+  azurerm_functionapp_app_name              = "${var.azurerm_resource_name_prefix}-functions-app-${var.environment_short}"
   azurerm_functionapp_storage_account_name  = "${var.azurerm_resource_name_prefix}funcstorage${var.environment_short}"
   azurerm_application_insights_name         = "${var.azurerm_resource_name_prefix}-appinsights-${var.environment_short}"
   azurerm_log_analytics_name                = "${var.azurerm_resource_name_prefix}-loganalytics-${var.environment_short}"
@@ -829,6 +830,12 @@ resource "azurerm_function_app" "azurerm_function_app_services" {
   https_only                = true
   enable_builtin_logging    = true
 
+  site_config = {
+    # We don't want the express server to idle
+    # so do not set `alwaysOn: false` in production
+    always_on = true
+  }
+
   app_settings = {
     # "AzureWebJobsStorage" = "${azurerm_storage_account.azurerm_functionapp_storage_account.primary_connection_string}"
 
@@ -855,6 +862,58 @@ resource "azurerm_function_app" "azurerm_function_app_services" {
     "MAIL_FROM_DEFAULT" = "${var.default_sender_email}"
 
     "WEBHOOK_CHANNEL_URL" = "${var.webhook_channel_url}${data.azurerm_key_vault_secret.webhook_channel_url_token.value}"
+  }
+
+  connection_string = [
+    {
+      name  = "COSMOSDB_KEY"
+      type  = "Custom"
+      value = "${azurerm_cosmosdb_account.azurerm_cosmosdb.primary_master_key}"
+    },
+    {
+      name  = "COSMOSDB_URI"
+      type  = "Custom"
+      value = "https://${azurerm_cosmosdb_account.azurerm_cosmosdb.name}.documents.azure.com:443/"
+    }
+  ]
+}
+
+resource "azurerm_function_app" "azurerm_function_app_app" {
+  name                      = "${local.azurerm_functionapp_app_name}"
+  location                  = "${azurerm_resource_group.azurerm_resource_group.location}"
+  resource_group_name       = "${azurerm_resource_group.azurerm_resource_group.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.azurerm_app_service_plan.id}"
+  storage_connection_string = "${azurerm_storage_account.azurerm_functionapp_storage_account.primary_connection_string}"
+  client_affinity_enabled   = false
+  version                   = "~2"
+
+  https_only                = true
+  enable_builtin_logging    = true
+
+  site_config = {
+    # We don't want the express server to idle
+    # so do not set `alwaysOn: false` in production
+    always_on = true
+  }
+
+  app_settings = {
+    # "AzureWebJobsStorage" = "${azurerm_storage_account.azurerm_functionapp_storage_account.primary_connection_string}"
+
+    "COSMOSDB_NAME" = "${local.azurerm_cosmosdb_documentdb_name}"
+
+    "QueueStorageConnection" = "${azurerm_storage_account.azurerm_storage_account.primary_connection_string}"
+
+    "APPINSIGHTS_INSTRUMENTATIONKEY" = "${azurerm_application_insights.azurerm_application_insights.instrumentation_key}"
+
+    # Avoid edit functions code from the Azure portal
+    "FUNCTION_APP_EDIT_MODE" = "readonly"
+
+    "WEBSITE_NODE_DEFAULT_VERSION" = "10.14.1"
+
+    # needed for deploying with functions core tools cli
+    "WEBSITE_RUN_FROM_PACKAGE" = "1"
+
+    "MESSAGE_CONTAINER_NAME" = "${azurerm_storage_blob.azurerm_message_blob.name}"
 
     "PUBLIC_API_URL" = "${coalesce(var.functions_public_api_url, local.default_functions_public_api_url)}"
 


### PR DESCRIPTION
This PR adds a new instance of Azure Functions that provides the APIs used by the app backend.

This instance works together with the one created in #31 that provides the APIs for 3rd party services.